### PR TITLE
fix typo in sanity check

### DIFF
--- a/drake_stuff/mbp_robot_arm_joint_limit_stuff/render_ur_urdfs.py
+++ b/drake_stuff/mbp_robot_arm_joint_limit_stuff/render_ur_urdfs.py
@@ -106,7 +106,7 @@ def convert_file_to_obj(mesh_file, suffix):
     pyassimp.export(scene, obj_file, file_type="obj")
     # Sanity check.
     scene_obj = load_mesh(obj_file)
-    extent_obj = get_mesh_extent(scene, mesh_file)
+    extent_obj = get_mesh_extent(scene_obj, mesh_file)
     np.testing.assert_equal(
         extent, extent_obj,
         err_msg=repr((mesh_file, obj_file)),


### PR DESCRIPTION
There's a typo on the sanity check used after conversion as it was comparing the mesh extents for the same scene, with this change it should use the new converted scene. 

However this will make the check to fail in many cases as the number of meshes doesn't seem to be consistent after conversions. I'm not sure if we should try to find a different way to do the sanity check.

Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>